### PR TITLE
Add docker/podman support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@
 FROM python:3
 
 # util-linux bash
-RUN apk --no-cache add gcc python3-dev musl-dev linux-headers
+#RUN apt install gcc python3-dev musl-dev linux-headers
 
-RUN adduser --disabled-password gramen
+#RUN adduser --disabled-password gramen
 
-USER gramen
+#USER gramen
 
 ENV PATH="/home/gramen/.local/bin:${PATH}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+#FROM python:3.13-rc-alpine # for some reason it needs lscpu and a bash folder?
+FROM python:3
+
+# util-linux bash
+RUN apk --no-cache add gcc python3-dev musl-dev linux-headers
+
+RUN adduser --disabled-password gramen
+
+USER gramen
+
+ENV PATH="/home/gramen/.local/bin:${PATH}"
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN python -m pip install --upgrade pip && python -m pip install --no-cache-dir -r requirements.txt
+
+COPY assets movie_streaming_site rxconfig.py ./
+
+ENTRYPOINT ["python"]
+
+CMD ["-m","reflex","run"]


### PR DESCRIPTION
Heyo

Nice wrapper, i decided to run this in a container but oddly enough i run into the following:
```
────────────────────── Initializing movie_streaming_site ───────────────────────
Warning: Your version (0.5.9) of reflex is out of date. Upgrade to 0.5.10 with
'pip install reflex --upgrade'
[17:48:30] Prior to reflex 0.4.0, rx.* components are based on    console.py:104
           Chakra UI. They are now based on Radix UI. To stick to
           Chakra UI, use rx.chakra.*.
                                                                  console.py:104
           Run `reflex script keep-chakra` to automatically       console.py:104
           update your app.
                                                                  console.py:104
           For more details, please see                           console.py:104
           https://reflex.dev/blog/2024-02-16-reflex-v0.4.0/
[17:48:40] Initializing the web directory.                        console.py:104
Success: Initialized movie_streaming_site
───────────────────────────── Starting Reflex App ──────────────────────────────
Warning: Your version (0.5.9) of reflex is out of date. Upgrade to 0.5.10 with
'pip install reflex --upgrade'
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/usr/local/lib/python3.12/site-packages/reflex/__main__.py", line 6, in <module>
    cli()
  File "/usr/local/lib/python3.12/site-packages/typer/main.py", line 338, in __call__
    raise e
  File "/usr/local/lib/python3.12/site-packages/typer/main.py", line 321, in __call__
    return get_command(self)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/typer/core.py", line 728, in main
    return _main(
           ^^^^^^
  File "/usr/local/lib/python3.12/site-packages/typer/core.py", line 197, in _main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/typer/main.py", line 703, in wrapper
    return callback(**use_params)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/reflex/reflex.py", line 287, in run
    _run(env, frontend, backend, frontend_port, backend_port, backend_host, loglevel)
  File "/usr/local/lib/python3.12/site-packages/reflex/reflex.py", line 213, in _run
    prerequisites.get_compiled_app()
  File "/usr/local/lib/python3.12/site-packages/reflex/utils/prerequisites.py", line 289, in get_compiled_app
    app_module = get_app(reload=reload)
                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/reflex/utils/prerequisites.py", line 262, in get_app
    app = __import__(module, fromlist=(constants.CompileVars.APP,))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/movie_streaming_site.py", line 2, in <module>
    from movie_streaming_site.components.moviecard import movie_card
ModuleNotFoundError: No module named 'movie_streaming_site.components'; 'movie_streaming_site' is not a package
```
I haven't gotten an api key yet, but this error was a bit odd and wanted to ask about it.

If you want to try it out yourself, you can copy that file into the repo locally
and run: podman build . -t test
podman run test

you can also pass an env file or variable directly in the run command and expose the right port once it seems to be working from the console
